### PR TITLE
Update make_var_mx6ul_dart_debian.sh

### DIFF
--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -337,7 +337,7 @@ function protected_install() {
 
         echo ""
         echo "###########################"
-        echo "## Fix missing packeges ###"
+        echo "## Fix missing packages ###"
         echo "###########################"
         echo ""
 
@@ -451,7 +451,7 @@ EOF
 
 	pr_info "rootfs: install selected debian packages (third-stage)"
 	chmod +x third-stage
-	LANG=C chroot ${ROOTFS_BASE} /third-stage
+	LANG=C chroot ${ROOTFS_BASE}/third-stage
 
 ## fourth-stage ##
 ### install variscite-bluetooth service


### PR DESCRIPTION
typo fix and removed obsolete space in path to invoke third-stage script